### PR TITLE
Use GetProcessImageFileNameW for non-UTF8 procnames

### DIFF
--- a/skrapa/windows/helpers.py
+++ b/skrapa/windows/helpers.py
@@ -166,7 +166,7 @@ kernel32.VirtualQueryEx.argtypes = [HANDLE, LPCVOID, LPVOID, SIZE_T]
 kernel32.GetSystemInfo.restype = None
 kernel32.OpenProcess.restype = HANDLE
 psapi.EnumProcesses.restype = SIZE_T
-psapi.GetProcessImageFileNameA.restype = SIZE_T
+psapi.GetProcessImageFileNameW.restype = SIZE_T
 
 
 MAX_PATH = 260

--- a/skrapa/windows/helpers.py
+++ b/skrapa/windows/helpers.py
@@ -302,7 +302,7 @@ def get_process_file_name(hProcess: int) -> str:
     kernel32.SetLastError(0)
 
     filename = (ctypes.c_char * MAX_PATH)()
-    process_name_length = psapi.GetProcessImageFileNameA(
+    process_name_length = psapi.GetProcessImageFileNameW(
         hProcess,
         filename,
         MAX_PATH,
@@ -311,7 +311,7 @@ def get_process_file_name(hProcess: int) -> str:
     if process_name_length == 0:
         raise GetProcessImageFileNameError(f"GetProcessImageFileName Error: 0x{kernel32.GetLastError():x}")
 
-    return filename[:process_name_length].decode("utf-8")
+    return filename[: process_name_length * 2].decode("utf-16-le")
 
 
 def get_process_architecture(hProcess: int) -> Architecture:


### PR DESCRIPTION
Fixes #1

Process names using non-UTF8 charsets would throw a UnicodeDecodeError, using the `GetProcessImageFileNameW` API call instead and using the UTF-16 decoding fixes this error.